### PR TITLE
Tighten context type

### DIFF
--- a/src/eval.ts
+++ b/src/eval.ts
@@ -417,7 +417,7 @@ const EMPTY: [undefined, undefined] = [undefined, undefined];
  * (2) All operations are "safe", i.e. when one of the arguments is undefined,
  *     we return undefined, rather than throwing an error.
  */
-function evaluate(node: AnyNode, context: Record<string, Object>): [any, any] {
+function evaluate(node: AnyNode, context: Record<string, unknown>): [any, any] {
   /* eslint-disable no-case-declarations */
   switch (node.type) {
     case NODE_TYPE.Array:


### PR DESCRIPTION
`context` couldn't really be any type - this tightening prevents
`evaluate` from being called on strings and numbers and enables
type-checking on `context`.

Ideally, the type would be even tighter, e.g.

```
type Context = {[identifier: string]: (
    Context | number | number[] | Function
    // TODO: tighten Function
)
```

but it looks like `context` is occasionally called on arbitrary Objects.

I hope this PR is still a step in the right direction :)

---

I agree to your [CLA](https://gist.github.com/plegner/5ad5b7be2948a4ad073c50b15ac01d39/bfeb9788f06d6a91de0ed2797c3460e047c484fd) - let me know if I need to do anything more than say this here.