### PR TITLE
Support SVG and JPEG export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mathigon/boost",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mathigon/boost",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "MIT",
       "dependencies": {
         "@mathigon/core": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mathigon/boost",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "license": "MIT",
   "homepage": "https://mathigon.io/boost",
   "repository": "mathigon/boost.js",

--- a/src/elements.ts
+++ b/src/elements.ts
@@ -29,6 +29,7 @@ interface EventListenerOptions {
   passive?: boolean;
 }
 
+
 // -----------------------------------------------------------------------------
 // Base Element Class
 


### PR DESCRIPTION
- Adds SVG and JPEG export functionality needed for https://github.com/mathigon/polypad/pull/18
- Makes PNG exports use a transparent background
- Makes JPEG exports use a white background
- Makes all exports use a light theme
- Fixes issues with tables in PNG export