### PR TITLE
Disallow calling `Function` and `eval`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Boost.ts
 
+> 🚨 Vulnerabilities found in `compile` and `evaluate`, these functions should not be used until this notice is removed after further testing!
+
 [![Build Status](https://github.com/mathigon/boost.js/workflows/CI%20Tests/badge.svg)](https://github.com/mathigon/boost.js/actions?query=workflow%3A%22CI+Tests%22)
 [![npm](https://img.shields.io/npm/v/@mathigon/boost.svg)](https://www.npmjs.com/package/@mathigon/boost)
 [![npm](https://img.shields.io/github/license/mathigon/boost.js.svg)](https://github.com/mathigon/boost.js/blob/master/LICENSE)

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -403,6 +403,8 @@ function parseSyntaxTree(expr: string) {
 const EMPTY: [undefined, undefined] = [undefined, undefined];
 type State = Record<string, unknown>;
 
+const FORBIDDEN_KEYS = ['__proto__', 'constructor', 'prototype'];
+
 /**
  * Returns [value, this]. We need to keep track of the `this` value so that
  * we can correctly set the context for object member method calls. Unlike
@@ -444,6 +446,7 @@ function evaluate(node: AnyNode, context: State, local: State): [any, any] {
       return evaluate(node.test, context, local)[0] ? consequent : alternate;
 
     case NODE_TYPE.Identifier:
+      if (FORBIDDEN_KEYS.includes(node.name)) return EMPTY;
       return [local[node.name] || context[node.name], undefined];
 
     case NODE_TYPE.Literal:
@@ -453,6 +456,7 @@ function evaluate(node: AnyNode, context: State, local: State): [any, any] {
       const object = evaluate(node.object, context, local)[0];
       const property = node.computed ? evaluate(node.property, context, local)[0] :
         (node.property as IdentifierNode).name;
+      if (FORBIDDEN_KEYS.includes(property)) return EMPTY;
       return object ? [object[property], object] : [undefined, undefined];
 
     case NODE_TYPE.UnaryOp:

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -431,7 +431,7 @@ function evaluate(node: AnyNode, context: State, local: State): [any, any] {
       const [fn, self] = evaluate(node.callee, context, local);
 
       // XSS / sandbox escape mitigation:
-      if(fn == Function || fn == eval) return EMPTY;
+      if (fn === Function || fn === eval) return EMPTY;
 
       const args = node.args.map((n) => evaluate(n, context, local)[0]);
       if (args.some(v => v === undefined) || typeof fn !== 'function') return EMPTY;

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -429,6 +429,10 @@ function evaluate(node: AnyNode, context: State, local: State): [any, any] {
     case NODE_TYPE.Call:
       // Note: we evaluate arguments even if fn is undefined.
       const [fn, self] = evaluate(node.callee, context, local);
+
+      // XSS / sandbox escape mitigation:
+      if(fn == Function || fn == eval) return EMPTY;
+
       const args = node.args.map((n) => evaluate(n, context, local)[0]);
       if (args.some(v => v === undefined) || typeof fn !== 'function') return EMPTY;
       return [fn.apply(self, args), undefined];

--- a/test/eval-test.ts
+++ b/test/eval-test.ts
@@ -74,6 +74,6 @@ tape('undefined keys', (test) => {
 
 
 tape('xss', (test) => {
-  test.equal(compile("x['__proto__']['constructor']('return 10')()")({x: () => {}}), undefined);
+  test.equal(compile('x[\'__proto__\'][\'constructor\'](\'return 10\')()')({x: () => {}}), undefined);
   test.end();
 });

--- a/test/eval-test.ts
+++ b/test/eval-test.ts
@@ -74,6 +74,15 @@ tape('undefined keys', (test) => {
 
 
 tape('xss', (test) => {
+
+  // No eval
   test.equal(compile('x[\'__proto__\'][\'constructor\'](\'return 10\')()')({x: () => {}}), undefined);
+  test.equal(compile(`x('1')`)({x: eval}), undefined);
+  test.equal(compile(`x('1')`)({x: Function}), undefined);
+
+  // No constructor or prototype
+  test.equal(compile(`x['constructor']`)({x: () => {}}), undefined);
+  test.equal(compile(`x['__proto__']`)({x: () => {}}), undefined);
+
   test.end();
 });

--- a/test/eval-test.ts
+++ b/test/eval-test.ts
@@ -71,3 +71,9 @@ tape('undefined keys', (test) => {
   test.equal(compile('!x')({}), true);
   test.end();
 });
+
+
+tape('xss', (test) => {
+  test.equal(compile("x['__proto__']['constructor']('return 10')()")({x: () => {}}), undefined);
+  test.end();
+});


### PR DESCRIPTION
XSS in any context with a function:

```js
const context = {x: () => {}};
compile(`x['__proto__']['constructor']('alert(1)')()`)(context)
```