### PR TITLE
Fix invalid query selector

### DIFF
--- a/src/components/modal.ts
+++ b/src/components/modal.ts
@@ -79,7 +79,7 @@ export class Modal extends CustomElementView {
     this.setAttr('aria-labelledby', TITLE_ID);
     this.onKey('Tab', (e: KeyboardEvent) => {
       if (!this.isOpen) return;
-      const $focus = this.$$('input:not([type=hidden]), a, button, textarea, [tabindex=0]');
+      const $focus = this.$$('input:not([type="hidden"]), a, button, textarea, [tabindex="0"]');
       if (e.shiftKey && e.target === $focus[0]._el) {
         e.preventDefault();
         last($focus).focus();


### PR DESCRIPTION
Pressing tab within an open modal leads to an 'Uncaught Syntax Error: Failed to execute 'querySelectorAll'... is not a valid selector'.