### PR TITLE
Delete batched callback before executing

### DIFF
--- a/src/observable.ts
+++ b/src/observable.ts
@@ -37,8 +37,10 @@ export function batch(callback: () => void) {
   callback();
   batchDepth--;
   if (batchDepth === 0) {
-    for (const [callback, state] of batchedCallbacks.entries()) callback(state);
-    batchedCallbacks.clear();
+    for (const [callback, state] of batchedCallbacks.entries()) {
+      batchedCallbacks.delete(callback);
+      callback(state);
+    }
   }
 }
 


### PR DESCRIPTION
If a `callback` within `batchedCallbacks` calls `assign` we have an infinite loop. Removing the callback from `batchedCallbacks` before executing it breaks this loop.

Consider a callback calling `assign`. `assign` will call `batch`, which will loop through all `batchedCallbacks` and execute each one. If one of those callbacks calls `assign` we will continue indefinitely.

By first removing the callback from `batchedCallbacks`, then executing we ensure that when the callback calls `assign` the callback is no longer part of the enqueued `batchedCallbacks`.

Minimal example with infinite loop:

```ts
import { observe } from "@mathigon/boost";

const state = observe<{ count: number }>({ count: 0 });
const model = observe<{ field: string }>({ field: "value" });

model.watch(({ field }) => {
  state.assign({ count: field.length });
});

model.assign({ field: "new value" });
```