### PR TITLE
Add readonly getters and setters for input fields

### DIFF
--- a/src/elements.ts
+++ b/src/elements.ts
@@ -1248,6 +1248,14 @@ export class InputView extends HTMLBaseView<InputFieldElement> {
     (this._el as HTMLInputElement).checked = value;
   }
 
+  get readonly() {
+    return (this._el as HTMLInputElement).readOnly;
+  }
+
+  set readonly(value: boolean) {
+    (this._el as HTMLInputElement).readOnly = value;
+  }
+
   get value() {
     return this._el.value;
   }


### PR DESCRIPTION
For tile weights in polypad we want groups to have a readonly input field. It feels best to add those options here.